### PR TITLE
Fix bug detecting merge commits

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const run = async () => {
 
 
   let noMergesCmd =
-    `output=$(git log --oneline origin/${BRANCH}...HEAD --merges) && [ -z "$output" ] || echo $output`;
+    `[[ -z "$(git log --oneline origin/${BRANCH}...HEAD --merges )" ]]`
   let correctBaseCmd =
     `[ "$(git merge-base origin/${BRANCH} HEAD)" = "$(git rev-parse origin/${BRANCH})" ]`;
 


### PR DESCRIPTION
The current implementation of merge commit detection can never report
failure. The command is structured like this:
`o=$(git cmd) && test || echo`

If the git cmd or test fail, then the echo will be run and the
whole command will exit with success (because the echo succeeded)

If the assignment and test pass, then the echo won't be run and the
command will exit with success because there was no failure.

Here the cmd and test are replaced with true and false, the echo cmd is
replaced with true. The echo $? shows us the exit status of the
expression.

```
$ true && true || true; echo $?
0
$ true && false || true; echo $?
0
$ false  && true || true; echo $?
0
$ false  && false || true; echo $?
0
```

This commit changes the structure of the command to this:
`[[ -z "$(git cmd)" ]]`
This is much simpler, if the git command outputs anything to stdout,
the expression will exit with failure. If stdout is empty then the
expression will exit with success.

```
$ [[ -z "$(true)" ]]; echo $?
0
$ [[ -z "$(false)" ]]; echo $?
0
$ [[ -z "$(date)" ]]; echo $?
1
```
Here we see that the exit code of the git command does not influence
the result of the overall expression, only whether anything is output
to stdout. This is ok for our usecase as git log gives the same exit
code when zero results are returned as when one or more are.

Related: ONYX-24026