### PR TITLE
Use single square brackets in shell commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const run = async () => {
 
 
   let noMergesCmd =
-    `[[ -z "$(git log --oneline origin/${BRANCH}...HEAD --merges )" ]]`
+    `[ -z "$(git log --oneline origin/${BRANCH}...HEAD --merges )" ]`
   let correctBaseCmd =
     `[ "$(git merge-base origin/${BRANCH} HEAD)" = "$(git rev-parse origin/${BRANCH})" ]`;
 


### PR DESCRIPTION
My previous commit tagged as (v2.0.1) fixed a logic error in
the shell script for determing if a branch contains merge commits,
however it uses double square brackets which aren't available in the
shell that executes the commands.

This commit changes the double square brackets for single square
brackets.

Related: ONYX-24026