### PR TITLE
Compensate for checkout@v2 checking out merge ref

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const runShellCmd = async (command, failureMessage) => {
         errorMessage += `\nStandard Error: ${stderr}`;
       if (error || errorMessage)
         core.setFailed(errorMessage);
-      core.debug(stdout);
+      console.log(stdout);
     });
 }
 
@@ -20,8 +20,34 @@ const run = async () => {
   const BASE_FAILURE = `Pull request must be rebased on ${BRANCH}`;
 
 
-  let noMergesCmd =
-    `[ -z "$(git log --oneline origin/${BRANCH}...HEAD --merges )" ]`
+  // Typical use of this action:
+  //  steps:
+  //  - name: Check out code
+  //    uses: actions/checkout@v2
+  //    with:
+  //      fetch-depth: 0
+  //  - name: Is Rebased on master?
+  //    uses: cyberark/enforce-rebase@onyx-24026-fix-merge-detection
+  //
+  // checkout@v2 checks out the pull request merged into the target branch by
+  // default. This confuses the merge commit detection logic as there is always
+  // a merge commit on the branch.
+  // This step could be done as part of the checkout action configuration
+  // see: https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
+  // However we checkout the head of the pull request branch here to avoid having to change
+  // the configuration of all users of this action.
+
+  let noMergesCmd = `merges="\$(git log --oneline origin/${BRANCH}...HEAD --merges )"; \
+  echo "--- Merges ---\\n\${merges}"; [ -z "\${merges}" ]`
+  if(process.env.GITHUB_EVENT_NAME == "pull_request"){
+    console.log("PR Detected, checking out PR Branch head before checking for merge commits");
+    noMergesCmd = `git checkout "${ process.env.GITHUB_HEAD_REF }" 2>&1 && `
+                  + noMergesCmd;
+  } else {
+    console.log("PR Not detected, skipping checkout");
+  }
+  console.log(`Command for checking for merge commits is ${noMergesCmd}`)
+
   let correctBaseCmd =
     `[ "$(git merge-base origin/${BRANCH} HEAD)" = "$(git rev-parse origin/${BRANCH})" ]`;
 


### PR DESCRIPTION
This action needs the git repo to be checked out at the head of the
PR branch, not at the merge commit of the PR branch and target branch.
checkout@v2 does checkout the merge commit, so this commit switches
back to the head of the PR branch before checking for merges.

Related: ONYX-24026